### PR TITLE
[FIX] Broken editor handling for sys_language_uid -1

### DIFF
--- a/Classes/EventListener/BeforePrepareConfigurationForEditorEventListener.php
+++ b/Classes/EventListener/BeforePrepareConfigurationForEditorEventListener.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\RteCKEditor\Form\Element\Event\BeforePrepareConfigurationForEditorEvent;
+use Throwable;
 
 #[AsEventListener(
     identifier: 'ai-suite/file-controls-event-listener',
@@ -26,7 +27,11 @@ class BeforePrepareConfigurationForEditorEventListener
         if (BackendUserUtility::checkPermissions('tx_aisuite_features:enable_rte_aiplugin')) {
             $sysLanguageUid = $event->getData()['databaseRow']['sys_language_uid'];
             $site = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($event->getData()['effectivePid']);
-            $siteLanguage = $site->getLanguageById((int)$sysLanguageUid);
+            try {
+                $siteLanguage = $site->getLanguageById((int)$sysLanguageUid);
+            } catch (Throwable $e) {
+                return;
+            }
             $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
             $pageRenderer->addInlineSetting('aiSuite', 'rteLanguageCode', $siteLanguage->getLocale()->getLanguageCode());
 


### PR DESCRIPTION
The given language does not exist within sites.
It also can not be resolved to a locale by default, further code and fallback logic, maybe with a configuration option, needs to be added.

Therefore the current fix will catch the situation and prevent adding the integration for editors.

That way the feature is gone, but elements can still be edited.

Resolves: #3