### PR TITLE
Allow HTTP Basic Auth

### DIFF
--- a/Classes/Service/MetadataService.php
+++ b/Classes/Service/MetadataService.php
@@ -7,6 +7,7 @@ namespace AutoDudes\AiSuite\Service;
 use AutoDudes\AiSuite\Domain\Repository\RequestsRepository;
 use AutoDudes\AiSuite\Exception\FetchedContentFailedException;
 use AutoDudes\AiSuite\Exception\UnableToFetchNewsRecordException;
+use AutoDudes\AiSuite\Utility\BasicAuthUtility;
 use AutoDudes\AiSuite\Utility\SiteUtility;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\PreviewUriBuilder;
@@ -146,14 +147,15 @@ class MetadataService
             throw new UnableToLinkToPageException(LocalizationUtility::translate('LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:AiSuite.unableToLinkToPage', null, [$pageId, $pageLanguage]));
         }
         $port = $previewUri->getPort() ? ':' . $previewUri->getPort() : '';
-        $uri = $previewUri->getScheme() . '://' . $previewUri->getHost() . $port . $previewUri->getPath();
+        $basicAuth = BasicAuthUtility::getBasicAuth();
+        $uri = $previewUri->getScheme() . '://' . $basicAuth . $previewUri->getHost() . $port . $previewUri->getPath();
         if ($previewUri->getScheme() === '' || $previewUri->getHost() === '') {
             $request = $GLOBALS['TYPO3_REQUEST'];
             $previewUri = $previewUri->withScheme($request->getUri()->getScheme());
             $previewUri = $previewUri->withHost($request->getUri()->getHost());
             $previewUri = $previewUri->withPort($request->getUri()->getPort());
             $port = $previewUri->getPort() ? ':' . $previewUri->getPort() : '';
-            $uri = $previewUri->getScheme() . '://' . $previewUri->getHost() . $port . $previewUri->getPath();
+            $uri = $previewUri->getScheme() . '://' . $basicAuth . $previewUri->getHost() . $port . $previewUri->getPath();
         }
         if (count($additionalQueryParameters) > 0) {
             return $uri . '?' . $previewUri->getQuery();

--- a/Classes/Utility/BasicAuthUtility.php
+++ b/Classes/Utility/BasicAuthUtility.php
@@ -22,7 +22,7 @@ class BasicAuthUtility
     {
         $auth = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('ai_suite', 'basicauth');
 
-        if ((bool)$auth['enable']) {
+        if ((bool)$auth['enable'] && !empty($auth['user']) && !empty($auth['pass'])) {
             return rawurlencode($auth['user'])
                 . ':'
                 . rawurlencode($auth['pass'])

--- a/Classes/Utility/BasicAuthUtility.php
+++ b/Classes/Utility/BasicAuthUtility.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace AutoDudes\AiSuite\Utility;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class BasicAuthUtility
+{
+    /**
+     * returns the basic auth prefix
+     * for example https://myuser:mypassword@myhost
+     *
+     * see rfc3986 section 3.2.1
+     *
+     * @return string
+     * @throws \TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException
+     * @throws \TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException
+     */
+    public static function getBasicAuth(): string
+    {
+        $auth = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('ai_suite', 'basicauth');
+
+        if ((bool)$auth['enable']) {
+            return rawurlencode(['user'])
+                . ':'
+                . rawurlencode($auth['pass'])
+                . '@';
+        }
+        return '';
+    }
+}

--- a/Classes/Utility/BasicAuthUtility.php
+++ b/Classes/Utility/BasicAuthUtility.php
@@ -23,7 +23,7 @@ class BasicAuthUtility
         $auth = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('ai_suite', 'basicauth');
 
         if ((bool)$auth['enable']) {
-            return rawurlencode(['user'])
+            return rawurlencode($auth['user'])
                 . ':'
                 . rawurlencode($auth['pass'])
                 . '@';

--- a/Resources/Private/Language/ext_conf.xlf
+++ b/Resources/Private/Language/ext_conf.xlf
@@ -39,6 +39,15 @@
             <trans-unit id="midjourneyId" resname="midjourneyId">
                 <source>Enter your Midjourney ID</source>
             </trans-unit>
+            <trans-unit id="basicauthenable" resname="basicauthenable">
+                <source>Enable Basic Authentication</source>
+            </trans-unit>
+            <trans-unit id="basicauthuser" resname="basicauthuser">
+                <source>Username</source>
+            </trans-unit>
+            <trans-unit id="basicauthpass" resname="basicauthpass">
+                <source>Password</source>
+            </trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -20,4 +20,10 @@ deeplApiMode =
 midjourneyApiKey =
 # cat=Bring your own keys; type=string; label=LLL:EXT:ai_suite/Resources/Private/Language/ext_conf.xlf:midjourneyId
 midjourneyId =
+# cat=HTTP Basic Auth; type=boolean; label=LLL:EXT:ai_suite/Resources/Private/Language/ext_conf.xlf:basicauthenable
+basicauth.enable = 0
+# cat=HTTP Basic Auth; type=string; label=LLL:EXT:ai_suite/Resources/Private/Language/ext_conf.xlf:basicauthuser
+basicauth.user =
+# cat=HTTP Basic Auth; type=string; label=LLL:EXT:ai_suite/Resources/Private/Language/ext_conf.xlf:basicauthpass
+basicauth.pass =
 


### PR DESCRIPTION
- Add settings for http basic authentication
- Use Basic Auth credentials when fetching content for metadata generation

(Feature is based on main-v12, tested in TYPO3 12.4.24)

resolves #7 by fetching the content from the preview url with the basic auth added, for example
https://myuser:mypassword@myhost.com/my-path