### PR TITLE
TYPO3 13 TCA migrations

### DIFF
--- a/Classes/Controller/Ajax/BackgroundTaskController.php
+++ b/Classes/Controller/Ajax/BackgroundTaskController.php
@@ -67,7 +67,7 @@ class BackgroundTaskController extends AbstractAjaxController
             $data = $request->getParsedBody();
             $backgroundTask = $this->backgroundTaskRepository->findByUuid($data['uuid']);
             if (empty($backgroundTask)) {
-                throw new \Exception('No background task with uuid ' . $data['uuid'] . ' found');
+                throw new \Exception('No background task with uuid ' . $data['uuid'] . ' found', 1127054494);
             }
 
             $datamap[$backgroundTask['table_name']][$backgroundTask['table_uid']][$backgroundTask['column']] = $data['inputValue'];
@@ -76,11 +76,11 @@ class BackgroundTaskController extends AbstractAjaxController
             $dataHandler->start($datamap, []);
             $dataHandler->process_datamap();
             if(count($dataHandler->errorLog) > 0) {
-                throw new \Exception(implode(', ', $dataHandler->errorLog));
+                throw new \Exception(implode(', ', $dataHandler->errorLog), 9980994828);
             }
             $affectedRows = $this->backgroundTaskRepository->deleteByUuid($data['uuid']);
             if ($affectedRows === 0) {
-                throw new \Exception('No background task with uuid ' . $data['uuid'] . ' found');
+                throw new \Exception('No background task with uuid ' . $data['uuid'] . ' found', 2465708325);
             }
             $response->getBody()->write(
                 json_encode(
@@ -111,7 +111,7 @@ class BackgroundTaskController extends AbstractAjaxController
             $uuids = $data['uuids'] ?? [];
 
             if (empty($uuids)) {
-                throw new \Exception('No UUIDs provided');
+                throw new \Exception('No UUIDs provided', 3351392257);
             }
             $answer = $this->requestService->sendDataRequest(
                 'handleBackgroundTask',
@@ -121,7 +121,7 @@ class BackgroundTaskController extends AbstractAjaxController
                 ]
             );
             if ($answer->getType() === 'Error') {
-                throw new \Exception('AI Suite Server error: ' . $answer->getResponseData()['message']);
+                throw new \Exception('AI Suite Server error: ' . $answer->getResponseData()['message'], 1349576736);
             }
             $deletedCount = $this->backgroundTaskRepository->deleteByUuids($uuids);
 
@@ -155,12 +155,12 @@ class BackgroundTaskController extends AbstractAjaxController
             $uuid = $data['uuid'] ?? '';
 
             if (empty($uuid)) {
-                throw new \Exception('No UUID provided');
+                throw new \Exception('No UUID provided', 4962972600);
             }
 
             $backgroundTask = $this->backgroundTaskRepository->findByUuid($uuid);
             if (empty($backgroundTask)) {
-                throw new \Exception('No background task with UUID ' . $uuid . ' found');
+                throw new \Exception('No background task with UUID ' . $uuid . ' found', 4549735004);
             }
             $answer = $this->requestService->sendDataRequest(
                 'handleBackgroundTask',
@@ -170,7 +170,7 @@ class BackgroundTaskController extends AbstractAjaxController
                 ]
             );
             if ($answer->getType() === 'Error') {
-                throw new \Exception('AI Suite Server error: ' . $answer->getResponseData()['message']);
+                throw new \Exception('AI Suite Server error: ' . $answer->getResponseData()['message'], 3216498943);
             }
             $this->backgroundTaskRepository->updateStatus([
                 $uuid => [

--- a/Classes/Controller/Ajax/MassActionController.php
+++ b/Classes/Controller/Ajax/MassActionController.php
@@ -280,7 +280,7 @@ class MassActionController extends AbstractAjaxController
             $dataHandler->start($datamap, []);
             $dataHandler->process_datamap();
             if(count($dataHandler->errorLog) > 0) {
-                throw new \Exception(implode(', ', $dataHandler->errorLog));
+                throw new \Exception(implode(', ', $dataHandler->errorLog), 1393022890);
             }
             $response->getBody()->write(
                 json_encode(
@@ -402,7 +402,7 @@ class MassActionController extends AbstractAjaxController
                 if ((int)$sysFileUid === 0) {
                     $fileReferenceRow = $this->sysFileReferenceRepository->findByUid((int)$sysFileReferenceUid);
                     if (count($fileReferenceRow) === 0 || !array_key_exists('uid_local', $fileReferenceRow[0])) {
-                        throw new \Exception('No file reference row found for sys file reference uid ' . $sysFileReferenceUid . '. It seems that the file reference was deleted in the meanwhile or is are some other inconsistency with the database.');
+                        throw new \Exception('No file reference row found for sys file reference uid ' . $sysFileReferenceUid . '. It seems that the file reference was deleted in the meanwhile or is are some other inconsistency with the database.', 4476383305);
                     }
                     $sysFileUid = (int)$fileReferenceRow[0]["uid_local"];
                 }
@@ -509,7 +509,7 @@ class MassActionController extends AbstractAjaxController
             $dataHandler->start($datamap, []);
             $dataHandler->process_datamap();
             if(count($dataHandler->errorLog) > 0) {
-                throw new \Exception(implode(', ', $dataHandler->errorLog));
+                throw new \Exception(implode(', ', $dataHandler->errorLog), 3176963809);
             }
             $response->getBody()->write(
                 json_encode(
@@ -730,7 +730,7 @@ class MassActionController extends AbstractAjaxController
             $dataHandler->start($datamap, []);
             $dataHandler->process_datamap();
             if(count($dataHandler->errorLog) > 0) {
-                throw new \Exception(implode(', ', $dataHandler->errorLog));
+                throw new \Exception(implode(', ', $dataHandler->errorLog), 7328472340);
             }
             $response->getBody()->write(
                 json_encode(

--- a/Classes/Service/MetadataService.php
+++ b/Classes/Service/MetadataService.php
@@ -134,7 +134,7 @@ class MetadataService
         $fetchedContent = $response->getBody()->getContents();
 
         if (empty($fetchedContent)) {
-            throw new FetchedContentFailedException($this->translationService->translate('AiSuite.fetchContentFailed'));
+            throw new FetchedContentFailedException($this->translationService->translate('AiSuite.fetchContentFailed'), 9805341171);
         }
         return $fetchedContent;
     }
@@ -165,9 +165,9 @@ class MetadataService
 
         if ($previewUri === null) {
             if (array_key_exists('tx_news_pi1[news]', $additionalQueryParameters) && array_key_exists('tx_news_pi1[action]', $additionalQueryParameters) && array_key_exists('tx_news_pi1[controller]', $additionalQueryParameters)) {
-                throw new UnableToFetchNewsRecordException($this->translationService->translate('AiSuite.unableToFetchNewsRecord', [$additionalQueryParameters['tx_news_pi1[news]'], $pageId]));
+                throw new UnableToFetchNewsRecordException($this->translationService->translate('AiSuite.unableToFetchNewsRecord', [$additionalQueryParameters['tx_news_pi1[news]'], $pageId]), 1519416051);
             }
-            throw new UnableToLinkToPageException($this->translationService->translate('AiSuite.unableToLinkToPage', [$pageId, $page['sys_language_uid']]));
+            throw new UnableToLinkToPageException($this->translationService->translate('AiSuite.unableToLinkToPage', [$pageId, $page['sys_language_uid']]), 7916090036);
         }
         return $this->siteService->buildAbsoluteUri($previewUri);
     }

--- a/Classes/Service/XliffService.php
+++ b/Classes/Service/XliffService.php
@@ -70,10 +70,10 @@ class XliffService implements SingletonInterface
         try {
             $fileData = file_get_contents($file);
             if ($fileData === false) {
-                throw new FileNotFoundException('File ' . $file . ' not found in EXT:' . $extKey . '.');
+                throw new FileNotFoundException('File ' . $file . ' not found in EXT:' . $extKey . '.', 8398198694);
             }
         } catch (\Exception $e) {
-            throw new FileNotFoundException('File ' . $file . ' not found in EXT:' . $extKey . '.');
+            throw new FileNotFoundException('File ' . $file . ' not found in EXT:' . $extKey . '.', 6168933624);
         }
         $xmlData = new \SimpleXMLElement($fileData);
         $rawData = self::simpleXMLElementToArray($xmlData);

--- a/Configuration/TCA/tx_aisuite_domain_model_custom_prompt_template.php
+++ b/Configuration/TCA/tx_aisuite_domain_model_custom_prompt_template.php
@@ -16,7 +16,6 @@ return [
         'label' => 'name',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'versioningWS' => true,
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
@@ -61,7 +60,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
-                    ['', 0],
+                    ['label' => '', 'value' => 0],
                 ],
                 'foreign_table' => 'tx_aisuite_domain_model_custom_prompt_template',
                 'foreign_table_where' => 'AND tx_aisuite_domain_model_custom_prompt_template.pid=###CURRENT_PID### AND tx_aisuite_domain_model_custom_prompt_template.sys_language_uid IN (-1,0)',
@@ -97,9 +96,7 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
             'config' => [
-                'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'eval' => 'datetime',
+                'type' => 'datetime',
                 'default' => 0,
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
@@ -110,9 +107,7 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
             'config' => [
-                'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'eval' => 'datetime',
+                'type' => 'datetime',
                 'default' => 0,
                 'range' => [
                     'upper' => mktime(0, 0, 0, 1, 1, 2038),
@@ -149,12 +144,12 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
-                    ['LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeGeneral', 'general'],
-                    ['LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopePageTree', 'pageTree'],
-                    ['LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeImageWizard', 'imageWizard'],
-                    ['LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeContentElement', 'contentElement'],
-                    ['LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeNewsRecord', 'newsRecord'],
-                    ['LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeEditContent', 'editContent'],
+                    ['label' => 'LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeGeneral', 'value' => 'general'],
+                    ['label' => 'LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopePageTree', 'value' => 'pageTree'],
+                    ['label' => 'LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeImageWizard', 'value' => 'imageWizard'],
+                    ['label' => 'LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeContentElement', 'value' => 'contentElement'],
+                    ['label' => 'LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeNewsRecord', 'value' => 'newsRecord'],
+                    ['label' => 'LLL:EXT:ai_suite/Resources/Private/Language/locallang.xlf:tx_aisuite.module.dashboard.card.managePromptTemplates.scopeEditContent', 'value' => 'editContent'],
                 ],
                 'size' => 1,
                 'eval' => 'trim',

--- a/Configuration/TCA/tx_aisuite_domain_model_server_prompt_template.php
+++ b/Configuration/TCA/tx_aisuite_domain_model_server_prompt_template.php
@@ -19,7 +19,6 @@ return [
         'label_alt_force' => true,
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'versioningWS' => true,
         'hideTable' => true,
         'languageField' => 'sys_language_uid',
@@ -62,7 +61,7 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'items' => [
-                    ['', 0],
+                    ['label' => '', 'value' => 0],
                 ],
                 'foreign_table' => 'tx_aisuiteserver_domain_model_prompttemplate',
                 'foreign_table_where' => 'AND tx_aisuiteserver_domain_model_prompttemplate.pid=###CURRENT_PID### AND tx_aisuiteserver_domain_model_prompttemplate.sys_language_uid IN (-1,0)',
@@ -98,9 +97,7 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.starttime',
             'config' => [
-                'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'eval' => 'datetime',
+                'type' => 'datetime',
                 'default' => 0,
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
@@ -111,9 +108,7 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.endtime',
             'config' => [
-                'type' => 'input',
-                'renderType' => 'inputDateTime',
-                'eval' => 'datetime',
+                'type' => 'datetime',
                 'default' => 0,
                 'range' => [
                     'upper' => mktime(0, 0, 0, 1, 1, 2038),

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,3 +1,5 @@
 TCEMAIN {
     translateToMessage =
 }
+
+templates.typo3/cms-backend.1720458914000 = autodudes/ai-suite:Resources/Private/

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -23,7 +23,5 @@ $EM_CONF['ai_suite'] = [
         ],
     ],
     'state' => 'stable',
-    'uploadfolder' => 0,
-    'clearCacheOnLoad' => 1,
     'version' => '13.5.1',
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -108,9 +108,6 @@ try {
         ];
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['ai_suite']
             = \AutoDudes\AiSuite\Hooks\TranslationHook::class;
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-            'templates.typo3/cms-backend.1720458914000 = autodudes/ai-suite:Resources/Private/'
-        );
     }
 } catch (\Throwable $e) {
 


### PR DESCRIPTION
Applied some missing TCA migrations

removed deprecated options from ext_emconf.php

- `clearCacheOnLoad` [Deprecation: #99019 - Deprecated ext_emconf.php clearCacheOnLoad](https://docs.typo3.org/permalink/changelog:deprecation-99019-1667905697)
- `uploadfolder`, // Deprecated since version 9.5

Added error codes to thrown Exceptions (typo3-rector rule AddErrorCodeToExceptionRector)

Added tsconfig that was loaded with addPageTsConfig() to Configuration/page.tsconfig Deprecation [#101799](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101799-ExtensionManagementUtilityaddPageTSConfig.html)