### PR TITLE
[FIX] Add description for module overview

### DIFF
--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -8,6 +8,9 @@
             <trans-unit id="mlang_labels_tablabel">
                 <source>AI Suite Dashboard</source>
             </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>The AI Suite optimizes the workflow of project managers, agencies and freelancers by using the latest AI technologies.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
<img width="389" height="245" alt="Bildschirmfoto 2026-02-05 um 13 48 17" src="https://github.com/user-attachments/assets/6bf447ba-e301-4b22-8a21-ea5da9070fd1" />

There is no desc in the about module. (/typo3/module/help/about)
Maybe u wanna add that