### PR TITLE
[BUGFIX] Check for backend user before reading it

### DIFF
--- a/Classes/Factory/SettingsFactory.php
+++ b/Classes/Factory/SettingsFactory.php
@@ -45,7 +45,7 @@ class SettingsFactory
     public function mergeExtConfAndUserGroupSettings(): array
     {
         try {
-            if ($this->backendUserService->getBackendUser()->isAdmin()) {
+            if (!$this->backendUserService->hasBackendUser() || $this->backendUserService->getBackendUser()->isAdmin()) {
                 return $this->extConf;
             }
             foreach ($this->extConf as $key => $value) {

--- a/Classes/Service/BackendUserService.php
+++ b/Classes/Service/BackendUserService.php
@@ -200,4 +200,9 @@ class BackendUserService implements SingletonInterface
     {
         return $GLOBALS['BE_USER'];
     }
+
+    public function hasBackendUser(): bool
+    {
+        return ($GLOBALS['BE_USER'] ?? null) instanceof BackendUserAuthentication;
+    }
 }


### PR DESCRIPTION
When adding a file to a FAL storage, ai_suite checks if it should be processed, including the settings of the logged in BE-User. If no BE user login is available, PHP throws a TypeError exception. This commonly happens during a file upload in the frontend, eg. via EXT:form.